### PR TITLE
Migrate to Confluent 3.0.0

### DIFF
--- a/examples/csv/example.properties
+++ b/examples/csv/example.properties
@@ -1,4 +1,4 @@
-job.id=plumber-csv
+application.id=plumber-csv
 bootstrap.servers=localhost:9092
 zookeeper.connect=localhost:2181
 schema.registry.url=http://localhost:8081

--- a/examples/demo/example.properties
+++ b/examples/demo/example.properties
@@ -1,4 +1,4 @@
-job.id=plumber-demo
+application.id=plumber-demo
 bootstrap.servers=localhost:9092
 zookeeper.connect=localhost:2181
 schema.registry.url=http://localhost:8081

--- a/examples/time/example.properties
+++ b/examples/time/example.properties
@@ -1,4 +1,4 @@
-job.id=plumber-time
+application.id=plumber-time
 bootstrap.servers=localhost:9092
 zookeeper.connect=localhost:2181
 schema.registry.url=http://localhost:8081

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
   </repositories>
   <properties>
     <java.version>1.8</java.version>
-    <kafka.version>0.9.1.0-cp1</kafka.version>
+    <kafka.version>0.10.0.0</kafka.version>
     <kafka.scala.version>2.11</kafka.scala.version>
     <scala.version>${kafka.scala.version}.7</scala.version>
-    <confluent.version>2.1.0-alpha1</confluent.version>
+    <confluent.version>3.0.0</confluent.version>
     <scalatest.version>2.2.6</scalatest.version>
     <mockito.version>1.10.19</mockito.version>
     <avro.version>1.7.7</avro.version>

--- a/src/main/scala/com/eneco/trading/kafka/streams/plumber/GenericAvroSerializer.scala
+++ b/src/main/scala/com/eneco/trading/kafka/streams/plumber/GenericAvroSerializer.scala
@@ -1,9 +1,28 @@
 package com.eneco.energy.kafka.streams.plumber
 
 import java.util
+
 import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
 import org.apache.kafka.common.Configurable
-import org.apache.kafka.common.serialization.{Deserializer, Serializer}
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
+
+class GenericAvroSerde[T] extends Serde[T] {
+  val s = new GenericAvroSerializer[T]
+  val d = new GenericAvroDeserializer[T]
+
+  def configure(map: util.Map[String, _], isKey: Boolean) = {
+    s.configure(map, isKey)
+    d.configure(map, isKey)
+  }
+
+  def close = {
+    s.close
+    d.close
+  }
+
+  def serializer : Serializer[T] = s
+  def deserializer : Deserializer[T] = d
+}
 
 // NOTE: Must have a public no-argument constructor (org.apache.kafka.common.utils.Utils.newInstance)
 class GenericAvroSerializer[T]() extends Serializer[T] with Configurable {

--- a/src/main/scala/com/eneco/trading/kafka/streams/plumber/TypeConversions.scala
+++ b/src/main/scala/com/eneco/trading/kafka/streams/plumber/TypeConversions.scala
@@ -6,7 +6,7 @@ import java.util.Properties
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Parser
 import org.apache.avro.generic.GenericRecord
-import org.apache.kafka.common.serialization._
+import org.apache.kafka.common.serialization.Serdes._
 import com.eneco.energy.kafka.streams.plumber.Properties._
 
 sealed trait MappingType
@@ -27,23 +27,12 @@ object MappingType {
     })
   }
 
-  def toSerializer(t: MappingType, ps: Properties, isKey: Boolean) = {
+  def toSerde(t: MappingType, ps: Properties, isKey: Boolean) = {
     val s = t match {
-      case LongType => new LongSerializer
-      case StringType => new StringSerializer
-      case AvroType(_) => new GenericAvroSerializer[GenericRecord]
-      case VoidType => new StringSerializer //TODO: create void serializer
-    }
-    s.configure(ps.toHashMap(), isKey)
-    s
-  }
-
-  def toDeserializer(t: MappingType, ps: Properties, isKey: Boolean): Deserializer[_] = {
-    val s = t match {
-      case LongType => new LongDeserializer
-      case StringType => new StringDeserializer
-      case AvroType(_) => new GenericAvroDeserializer[GenericRecord]
-      case VoidType => new StringDeserializer //TODO: create void deserializer
+      case LongType => new LongSerde
+      case StringType => new StringSerde
+      case AvroType(_) => new GenericAvroSerde[GenericRecord]
+      case VoidType => new StringSerde //TODO: create void serializer
     }
     s.configure(ps.toHashMap(), isKey)
     s


### PR DESCRIPTION
I don't know what the fixedProperties() were for, but it has the tag "TODO: is work around Streams API, revisit in 0.10?". Is it still needed?
